### PR TITLE
Fix logging undefined instead of the proper error message in case of a login error.

### DIFF
--- a/lib/src/middleware/authentication.ts
+++ b/lib/src/middleware/authentication.ts
@@ -50,7 +50,7 @@ export const asgardeoExpressAuth = (
                     onSignIn(res, response);
                 }
             } catch (e: any) {
-                Logger.error(e.message.message);
+                Logger.error(e.message);
                 onError(res, e);
             }
         }


### PR DESCRIPTION
## Purpose
> $Subject. `undefined` is logged because a non existing property of the error object has been passed to the error logging method.
